### PR TITLE
Feat/header progress bar

### DIFF
--- a/src/app/contexts/FlipContext.tsx
+++ b/src/app/contexts/FlipContext.tsx
@@ -1,0 +1,8 @@
+import { createContext, useContext } from "react";
+
+// FlippableChar의 Flippable 여부를 관리하는 context
+const FlipContext = createContext(false);
+
+const useFlipContext = () => useContext(FlipContext);
+
+export { FlipContext, useFlipContext };

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,3 +1,5 @@
+@import url("https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/static/pretendard.min.css");
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -28,7 +28,7 @@ export default async function Home() {
   });
 
   return (
-    <main className="bg-basic w-full flex-grow overflow-hidden">
+    <main className="bg-basic z-0 w-full flex-grow overflow-hidden">
       <RandomWrapper cards={cards} />
     </main>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -28,7 +28,7 @@ export default async function Home() {
   });
 
   return (
-    <main className="flex-grow overflow-hidden w-full">
+    <main className="bg-basic w-full flex-grow overflow-hidden">
       <RandomWrapper cards={cards} />
     </main>
   );

--- a/src/app/playground/page.tsx
+++ b/src/app/playground/page.tsx
@@ -13,7 +13,9 @@ export type CardType = {
 };
 
 export default function Playground() {
-  const startIndex = 1;
+  // 테스트용으로 원하는 인덱스 값 설정하기
+  const startIndex = 8;
+  const prevIndex = 0;
   const testCards: CardType[] = [
     {
       id: "1",
@@ -183,7 +185,7 @@ export default function Playground() {
 
   return (
     <main className="h-full w-full overflow-hidden">
-      <Card cards={testCards} startIndex={startIndex} />
+      <Card cards={testCards} currentIndex={startIndex} prevIndex={prevIndex} />
     </main>
   );
 }

--- a/src/components/Caption/index.tsx
+++ b/src/components/Caption/index.tsx
@@ -30,7 +30,7 @@ export default function Caption({ cards, currentIndex }: Props) {
     cards.length;
 
   return (
-    <div className="mt-2 flex w-full justify-between whitespace-pre text-sm font-normal lg:w-3/4vh lg:text-base">
+    <div className="z-20 mt-2 flex w-full justify-between whitespace-pre text-sm font-normal lg:w-3/4vh lg:text-base">
       <p className="w-30 flex w-1/3 justify-start">{currentCard.createdBy}</p>
       <p className="w-30 flex w-1/3 justify-center">
         {currentIndex + 1 + "/" + cards.length}

--- a/src/components/Card/index.tsx
+++ b/src/components/Card/index.tsx
@@ -40,8 +40,8 @@ export default function Card({ cards, currentIndex, prevIndex }: Props) {
   }, [currentIndex, cards.length]);
 
   return (
-    <div className="z-20 flex h-full w-full flex-col items-center justify-center p-2 lg:p-0">
-      <div className="flex aspect-square w-full items-center justify-center [perspective:2000px] lg:h-3/4vh lg:w-3/4vh">
+    <div className="flex h-full w-full flex-col items-center justify-center p-2 lg:p-0">
+      <div className="z-20 flex aspect-square w-full items-center justify-center [perspective:2000px] lg:h-3/4vh lg:w-3/4vh">
         {cards.map((card, index) => {
           const rotationAngle = rotationAngles[index];
 

--- a/src/components/Card/index.tsx
+++ b/src/components/Card/index.tsx
@@ -40,7 +40,7 @@ export default function Card({ cards, currentIndex, prevIndex }: Props) {
   }, [currentIndex, cards.length]);
 
   return (
-    <div className="flex h-full w-full flex-col items-center justify-center p-2 lg:p-0">
+    <div className="z-20 flex h-full w-full flex-col items-center justify-center p-2 lg:p-0">
       <div className="flex aspect-square w-full items-center justify-center [perspective:2000px] lg:h-3/4vh lg:w-3/4vh">
         {cards.map((card, index) => {
           const rotationAngle = rotationAngles[index];
@@ -48,7 +48,7 @@ export default function Card({ cards, currentIndex, prevIndex }: Props) {
           return (
             <div
               key={card.id}
-              className="absolute aspect-square w-full transform bg-white text-xs text-black shadow-lg transition-transform duration-1800 ease-in-out [backface-visibility:hidden] md:text-base"
+              className="absolute aspect-square w-full transform bg-white text-xs text-black transition-transform duration-1800 ease-in-out [backface-visibility:hidden] md:text-base"
               style={{ transform: `rotateY(${rotationAngle}deg)` }}
             >
               {/* 카드 타입에 따라 조건부 렌더링 */}

--- a/src/components/Card/index.tsx
+++ b/src/components/Card/index.tsx
@@ -3,7 +3,6 @@
 import { useState, useEffect } from "react";
 import { CardType } from "@/app/page";
 import Caption from "@/components/Caption";
-import ProgressBar from "@/components/ProgressBar";
 
 type Props = {
   cards: CardType[];

--- a/src/components/Card/index.tsx
+++ b/src/components/Card/index.tsx
@@ -1,53 +1,47 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { CardType } from "@/app/page";
 import Caption from "@/components/Caption";
 import ProgressBar from "@/components/ProgressBar";
 
 type Props = {
   cards: CardType[];
-  startIndex: number;
+  currentIndex: number;
+  prevIndex: number | null;
 };
 
-export default function Card({ cards, startIndex }: Props) {
-  const [currentIndex, setCurrentIndex] = useState(startIndex);
+export default function Card({ cards, currentIndex, prevIndex }: Props) {
+  // const [currentIndex, setCurrentIndex] = useState(startIndex);
   // 각 카드들의 회전 각도를 저장하는 state. 처음 렌더링에서 보여질 카드만 0도(앞면)로 설정.
   const [rotationAngles, setRotationAngles] = useState<number[]>(() =>
     Array.from({ length: cards.length }, (_, i) =>
-      i === startIndex ? 0 : 180,
+      i === currentIndex ? 0 : 180,
     ),
   );
 
-  const handleFlip = (event: React.MouseEvent<HTMLDivElement>) => {
-    const cardWidth = event.currentTarget.offsetWidth;
-    const cardLeft = event.currentTarget.offsetLeft;
-
-    const newAngles = [...rotationAngles];
-
-    if (event.clientX > cardLeft + cardWidth / 2) {
-      // 화면 우측 클릭
-      if (currentIndex === cards.length - 1) return;
-      newAngles[currentIndex] += 180;
-      newAngles[currentIndex + 1] += 180;
-      setCurrentIndex((prevIndex) => prevIndex + 1);
+  // currentIndex가 변경될 때마다 회전 각도 업데이트
+  useEffect(() => {
+    // 다음 카드로 넘기는 경우
+    if (currentIndex > prevIndex!) {
+      setRotationAngles((prevArr) =>
+        prevArr.map((val, idx) =>
+          idx === currentIndex || idx === prevIndex ? val + 180 : val,
+        ),
+      );
     } else {
-      // 화면 좌측 클릭
-      if (currentIndex === 0) return;
-      newAngles[currentIndex] -= 180;
-      newAngles[currentIndex - 1] -= 180;
-      setCurrentIndex((prevIndex) => prevIndex - 1);
+      // 이전 카드로 넘기는 경우
+      setRotationAngles((prevArr) =>
+        prevArr.map((val, idx) =>
+          idx === currentIndex || idx === prevIndex ? val - 180 : val,
+        ),
+      );
     }
-
-    setRotationAngles(newAngles);
-  };
+  }, [currentIndex, cards.length]);
 
   return (
     <div className="flex h-full w-full flex-col items-center justify-center p-2 lg:p-0">
-      <div
-        className="flex aspect-square w-full items-center justify-center [perspective:2000px] lg:h-3/4vh lg:w-3/4vh"
-        onClick={handleFlip}
-      >
+      <div className="flex aspect-square w-full items-center justify-center [perspective:2000px] lg:h-3/4vh lg:w-3/4vh">
         {cards.map((card, index) => {
           const rotationAngle = rotationAngles[index];
 

--- a/src/components/FlippableChar/index.tsx
+++ b/src/components/FlippableChar/index.tsx
@@ -1,0 +1,26 @@
+import { useEffect } from "react";
+import { useFlipContext } from "@/app/contexts/FlipContext";
+
+type FlippableCharProps = {
+  char: string;
+};
+
+export default function FlippableChar({ char }: FlippableCharProps) {
+  const isFlippable = useFlipContext();
+
+  return (
+    <span
+      className="relative inline-block"
+      style={{
+        transition: "transform 0.5s",
+        transform: isFlippable ? "rotateY(180deg)" : "rotateY(0deg)",
+      }}
+    >
+      <span
+        className="border-1 pointer-events-none absolute h-full border-black px-[0.6rem]"
+        style={{ transform: "translate(-50%, -50%)", top: "50%", left: "50%" }}
+      ></span>
+      <span className="inline-block">{char}</span>
+    </span>
+  );
+}

--- a/src/components/FlippableChar/index.tsx
+++ b/src/components/FlippableChar/index.tsx
@@ -18,7 +18,7 @@ export default function FlippableChar({ char }: FlippableCharProps) {
     >
       <span
         className="border-1 pointer-events-none absolute h-full border-black px-[0.6rem]"
-        style={{ transform: "translate(-50%, -50%)", top: "50%", left: "50%" }}
+        style={{ transform: "translate(-50%, 0)", left: "50%" }}
       ></span>
       <span className="inline-block">{char}</span>
     </span>

--- a/src/components/FlippableChar/index.tsx
+++ b/src/components/FlippableChar/index.tsx
@@ -17,7 +17,7 @@ export default function FlippableChar({ char }: FlippableCharProps) {
     >
       {/* flippableChar를 감싸는 border */}
       <span
-        className="border-1 pointer-events-none absolute h-full border-black px-[0.6rem]"
+        className="border-1 pointer-events-none absolute h-full border-black px-[0.5rem]"
         style={{ transform: "translate(-50%, 0)", left: "50%" }}
       ></span>
       {/* flippableChar */}

--- a/src/components/FlippableChar/index.tsx
+++ b/src/components/FlippableChar/index.tsx
@@ -1,4 +1,3 @@
-import { useEffect } from "react";
 import { useFlipContext } from "@/app/contexts/FlipContext";
 
 type FlippableCharProps = {
@@ -12,14 +11,16 @@ export default function FlippableChar({ char }: FlippableCharProps) {
     <span
       className="relative inline-block"
       style={{
-        transition: "transform 0.5s",
+        transition: "transform 0.8s",
         transform: isFlippable ? "rotateY(180deg)" : "rotateY(0deg)",
       }}
     >
+      {/* flippableChar를 감싸는 border */}
       <span
         className="border-1 pointer-events-none absolute h-full border-black px-[0.6rem]"
         style={{ transform: "translate(-50%, 0)", left: "50%" }}
       ></span>
+      {/* flippableChar */}
       <span className="inline-block">{char}</span>
     </span>
   );

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import { useState, useEffect } from "react";
 import Tab from "@/components/Tab";
+import { tabInfo } from "@/lib/tabInfo";
 
 type HeaderProps = {
   currentIndex: number;
@@ -11,28 +12,6 @@ export default function Header({ currentIndex, length }: HeaderProps) {
   const [windowWidth, setWindowWidth] = useState<number>(
     typeof window !== "undefined" ? window.innerWidth : 0,
   );
-  const tabs = [
-    { name: "home", path: "/", flippableChar: "e", flippableIndex: 3 },
-    {
-      name: "rules and terms",
-      path: "/rules-terms",
-      flippableChar: "t",
-      flippableIndex: 10,
-    },
-    {
-      name: "archive",
-      path: "/archive",
-      flippableChar: "h",
-      flippableIndex: 3,
-    },
-    { name: "about", path: "/about", flippableChar: "a", flippableIndex: 0 },
-    {
-      name: "subscribe",
-      path: "/subscribe",
-      flippableChar: "b",
-      flippableIndex: 2,
-    },
-  ];
 
   useEffect(() => {
     const handleResize = () => {
@@ -58,11 +37,12 @@ export default function Header({ currentIndex, length }: HeaderProps) {
           transform: `translateX(${((windowWidth - maxWidth) / (length - 1)) * currentIndex}px)`,
         }}
       >
-        {tabs.map((tab, i) => {
+        {tabInfo.map((tab, i) => {
           return (
             <Link href={tab.path} key={i}>
               <Tab
                 text={tab.name}
+                path={tab.path}
                 flippableChar={tab.flippableChar}
                 flippableIndex={tab.flippableIndex}
               />

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -1,6 +1,11 @@
 import Link from "next/link";
 
-export default function Header() {
+type HeaderProps = {
+  currentIndex: number;
+  length: number;
+};
+
+export default function Header({ currentIndex, length }: HeaderProps) {
   const tabs = [
     { name: "HOME", path: "/" },
     { name: "RULES & TERMS", path: "/rules-terms" },
@@ -9,9 +14,17 @@ export default function Header() {
     { name: "SUBSCRIBE", path: "/subscribe" },
   ];
 
+  const headerWidth = window.innerWidth / length;
+
   return (
     <header>
-      <nav className="flex w-full justify-between p-4">
+      <nav
+        className="absolute flex h-full flex-col bg-slate-200 p-4"
+        style={{
+          width: `${headerWidth}px`,
+          left: `${headerWidth * currentIndex}px`,
+        }}
+      >
         {tabs.map((tab, i) => {
           return (
             <Link href={tab.path} key={i}>

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -7,22 +7,22 @@ type HeaderProps = {
 
 export default function Header({ currentIndex, length }: HeaderProps) {
   const tabs = [
-    { name: "HOME", path: "/" },
-    { name: "RULES & TERMS", path: "/rules-terms" },
-    { name: "ARCHIVE", path: "/archive" },
-    { name: "ABOUT", path: "/about" },
-    { name: "SUBSCRIBE", path: "/subscribe" },
+    { name: "home", path: "/" },
+    { name: "rules and terms", path: "/rules-terms" },
+    { name: "archive", path: "/archive" },
+    { name: "about", path: "/about" },
+    { name: "subscribe", path: "/subscribe" },
   ];
-
-  const headerWidth = window.innerWidth / length;
+  const maxWidth = 150;
+  const headerWidth = Math.max(window.innerWidth / length, maxWidth);
 
   return (
     <header>
       <nav
-        className="absolute flex h-full flex-col bg-slate-200 p-4"
+        className="from-header to-basic absolute z-10 flex h-full flex-col bg-gradient-to-r p-2 font-sans font-light"
         style={{
           width: `${headerWidth}px`,
-          left: `${headerWidth * currentIndex}px`,
+          left: `${((window.innerWidth - maxWidth) / (length - 1)) * currentIndex}px`,
         }}
       >
         {tabs.map((tab, i) => {

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import { useState, useEffect } from "react";
 
 type HeaderProps = {
   currentIndex: number;
@@ -6,6 +7,9 @@ type HeaderProps = {
 };
 
 export default function Header({ currentIndex, length }: HeaderProps) {
+  const [windowWidth, setWindowWidth] = useState<number>(
+    typeof window !== "undefined" ? window.innerWidth : 0,
+  );
   const tabs = [
     { name: "home", path: "/" },
     { name: "rules and terms", path: "/rules-terms" },
@@ -13,16 +17,29 @@ export default function Header({ currentIndex, length }: HeaderProps) {
     { name: "about", path: "/about" },
     { name: "subscribe", path: "/subscribe" },
   ];
+
+  useEffect(() => {
+    const handleResize = () => {
+      setWindowWidth(window.innerWidth);
+    };
+
+    window.addEventListener("resize", handleResize);
+
+    return () => {
+      window.removeEventListener("resize", handleResize);
+    };
+  });
+
   const maxWidth = 150;
-  const headerWidth = Math.max(window.innerWidth / length, maxWidth);
+  const headerWidth = Math.max(windowWidth / length, maxWidth);
 
   return (
     <header>
       <nav
-        className="from-header to-basic absolute z-10 flex h-full flex-col bg-gradient-to-r p-2 font-sans font-light"
+        className="from-header to-basic absolute z-10 flex h-full transform flex-col bg-gradient-to-r p-2 font-sans font-light transition-transform duration-1800 ease-in-out"
         style={{
           width: `${headerWidth}px`,
-          left: `${((window.innerWidth - maxWidth) / (length - 1)) * currentIndex}px`,
+          transform: `translateX(${((windowWidth - maxWidth) / (length - 1)) * currentIndex}px)`,
         }}
       >
         {tabs.map((tab, i) => {

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import { useState, useEffect } from "react";
+import Tab from "@/components/Tab";
 
 type HeaderProps = {
   currentIndex: number;
@@ -11,11 +12,26 @@ export default function Header({ currentIndex, length }: HeaderProps) {
     typeof window !== "undefined" ? window.innerWidth : 0,
   );
   const tabs = [
-    { name: "home", path: "/" },
-    { name: "rules and terms", path: "/rules-terms" },
-    { name: "archive", path: "/archive" },
-    { name: "about", path: "/about" },
-    { name: "subscribe", path: "/subscribe" },
+    { name: "home", path: "/", flippableChar: "e", flippableIndex: 3 },
+    {
+      name: "rules and terms",
+      path: "/rules-terms",
+      flippableChar: "t",
+      flippableIndex: 10,
+    },
+    {
+      name: "archive",
+      path: "/archive",
+      flippableChar: "h",
+      flippableIndex: 3,
+    },
+    { name: "about", path: "/about", flippableChar: "a", flippableIndex: 0 },
+    {
+      name: "subscribe",
+      path: "/subscribe",
+      flippableChar: "b",
+      flippableIndex: 2,
+    },
   ];
 
   useEffect(() => {
@@ -45,7 +61,11 @@ export default function Header({ currentIndex, length }: HeaderProps) {
         {tabs.map((tab, i) => {
           return (
             <Link href={tab.path} key={i}>
-              <button key={i}>{tab.name}</button>
+              <Tab
+                text={tab.name}
+                flippableChar={tab.flippableChar}
+                flippableIndex={tab.flippableIndex}
+              />
             </Link>
           );
         })}

--- a/src/components/RandomWrapper/index.tsx
+++ b/src/components/RandomWrapper/index.tsx
@@ -8,23 +8,40 @@ type Props = {
   cards: CardType[];
 };
 
+// 인덱스를 통해 헤더와 카드의 상태를 결정
 export default function RandomWrapper({ cards }: Props) {
-  const [startIndex, setStartIndex] = useState<number | null>(null);
+  const [currentIndex, setCurrentIndex] = useState<number | null>(null);
+  const [prevIndex, setPrevIndex] = useState<number | null>(null);
+
+  const handleFlip = (event: React.MouseEvent<HTMLDivElement>) => {
+    const divWidth = event.currentTarget.offsetWidth;
+    if (event.clientX > divWidth / 2) {
+      setCurrentIndex((prevIndex) => prevIndex! + 1);
+    } else {
+      setCurrentIndex((prevIndex) => prevIndex! - 1);
+    }
+  };
 
   // 클라이언트 사이드에서 랜덤한 인덱스 설정 (서버 캐싱 방지)
   useEffect(() => {
     const randomIndex = Math.floor(Math.random() * cards.length);
-    setStartIndex(randomIndex);
+    setCurrentIndex(randomIndex);
   }, [cards.length]);
 
+  useEffect(() => {
+    if (currentIndex !== null) {
+      setPrevIndex(currentIndex);
+    }
+  }, [currentIndex]);
+
   // Fallback UI
-  if (startIndex === null) {
+  if (currentIndex === null) {
     return <div>Loading...</div>;
   }
 
   return (
-    <>
-      <Card cards={cards} startIndex={startIndex} />
-    </>
+    <div className="flex h-full w-full items-center" onClick={handleFlip}>
+      <Card cards={cards} currentIndex={currentIndex} prevIndex={prevIndex} />
+    </div>
   );
 }

--- a/src/components/RandomWrapper/index.tsx
+++ b/src/components/RandomWrapper/index.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from "react";
 import Card from "@/components/Card";
+import Header from "@/components/Header";
 import { CardType } from "@/app/page";
 
 type Props = {
@@ -40,8 +41,11 @@ export default function RandomWrapper({ cards }: Props) {
   }
 
   return (
-    <div className="flex h-full w-full items-center" onClick={handleFlip}>
-      <Card cards={cards} currentIndex={currentIndex} prevIndex={prevIndex} />
-    </div>
+    <>
+      <Header currentIndex={currentIndex} length={cards.length} />
+      <div className="flex h-full w-full items-center" onClick={handleFlip}>
+        <Card cards={cards} currentIndex={currentIndex} prevIndex={prevIndex} />
+      </div>
+    </>
   );
 }

--- a/src/components/RandomWrapper/index.tsx
+++ b/src/components/RandomWrapper/index.tsx
@@ -16,9 +16,9 @@ export default function RandomWrapper({ cards }: Props) {
 
   const handleFlip = (event: React.MouseEvent<HTMLDivElement>) => {
     const divWidth = event.currentTarget.offsetWidth;
-    if (event.clientX > divWidth / 2) {
+    if (event.clientX > divWidth / 2 && currentIndex! < cards.length - 1) {
       setCurrentIndex((prevIndex) => prevIndex! + 1);
-    } else {
+    } else if (event.clientX < divWidth / 2 && currentIndex! > 0) {
       setCurrentIndex((prevIndex) => prevIndex! - 1);
     }
   };
@@ -29,6 +29,7 @@ export default function RandomWrapper({ cards }: Props) {
     setCurrentIndex(randomIndex);
   }, [cards.length]);
 
+  // prevIndex를 Card Component에 props로 전달해주기 위함
   useEffect(() => {
     if (currentIndex !== null) {
       setPrevIndex(currentIndex);

--- a/src/components/Tab/index.tsx
+++ b/src/components/Tab/index.tsx
@@ -1,0 +1,30 @@
+// Header에 들어가는 Tab
+import FlippableChar from "../FlippableChar";
+import { FlipContext } from "@/app/contexts/FlipContext";
+import { useState } from "react";
+
+type TabProps = {
+  text: string;
+  flippableChar: string;
+  flippableIndex: number;
+};
+
+export default function Tab({ text, flippableChar, flippableIndex }: TabProps) {
+  const [isHovered, setIsHovered] = useState(false);
+  const beforeFlippable = text.slice(0, flippableIndex);
+  const afterFlippable = text.slice(flippableIndex + 1);
+
+  return (
+    <FlipContext.Provider value={isHovered}>
+      <div
+        onMouseEnter={() => setIsHovered(true)}
+        onMouseLeave={() => setIsHovered(false)}
+        className="tracking-wide"
+      >
+        {beforeFlippable}
+        <FlippableChar char={flippableChar} />
+        {afterFlippable}
+      </div>
+    </FlipContext.Provider>
+  );
+}

--- a/src/components/Tab/index.tsx
+++ b/src/components/Tab/index.tsx
@@ -28,7 +28,7 @@ export default function Tab({
       <div
         onMouseEnter={() => setIsFlipped((prevState: boolean) => !prevState)}
         onMouseLeave={() => setIsFlipped((prevState: boolean) => !prevState)}
-        className="tracking-wide"
+        className="text-sm tracking-wide"
       >
         {beforeFlippable}
         <FlippableChar char={flippableChar} />

--- a/src/components/Tab/index.tsx
+++ b/src/components/Tab/index.tsx
@@ -2,23 +2,32 @@
 import FlippableChar from "../FlippableChar";
 import { FlipContext } from "@/app/contexts/FlipContext";
 import { useState } from "react";
+import { usePathname } from "next/navigation";
 
 type TabProps = {
   text: string;
+  path: string;
   flippableChar: string;
   flippableIndex: number;
 };
 
-export default function Tab({ text, flippableChar, flippableIndex }: TabProps) {
-  const [isHovered, setIsHovered] = useState(false);
+export default function Tab({
+  text,
+  path,
+  flippableChar,
+  flippableIndex,
+}: TabProps) {
+  const pathname = usePathname();
+  const [isFlipped, setIsFlipped] = useState<boolean>(pathname !== path);
+
   const beforeFlippable = text.slice(0, flippableIndex);
   const afterFlippable = text.slice(flippableIndex + 1);
 
   return (
-    <FlipContext.Provider value={isHovered}>
+    <FlipContext.Provider value={isFlipped}>
       <div
-        onMouseEnter={() => setIsHovered(true)}
-        onMouseLeave={() => setIsHovered(false)}
+        onMouseEnter={() => setIsFlipped((prevState: boolean) => !prevState)}
+        onMouseLeave={() => setIsFlipped((prevState: boolean) => !prevState)}
         className="tracking-wide"
       >
         {beforeFlippable}

--- a/src/lib/tabInfo.ts
+++ b/src/lib/tabInfo.ts
@@ -1,0 +1,22 @@
+export const tabInfo = [
+  { name: "home", path: "/", flippableChar: "e", flippableIndex: 3 },
+  {
+    name: "rules and terms",
+    path: "/rules-terms",
+    flippableChar: "t",
+    flippableIndex: 10,
+  },
+  {
+    name: "archive",
+    path: "/archive",
+    flippableChar: "h",
+    flippableIndex: 3,
+  },
+  { name: "about", path: "/about", flippableChar: "a", flippableIndex: 0 },
+  {
+    name: "subscribe",
+    path: "/subscribe",
+    flippableChar: "b",
+    flippableIndex: 2,
+  },
+];

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -8,6 +8,9 @@ const config: Config = {
   ],
   theme: {
     extend: {
+      borderWidth: {
+        "1": "1px",
+      },
       colors: {
         basic: "#F2F2F2",
         header: "#CCCCCC",

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -23,6 +23,7 @@ const config: Config = {
       },
       fontFamily: {
         KoPub: ["KoPubWorldBatang", "serif"],
+        sans: ["Pretendard", "sans-serif"],
       },
       transitionDuration: {
         "1500": "1500ms",

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -8,6 +8,10 @@ const config: Config = {
   ],
   theme: {
     extend: {
+      colors: {
+        basic: "#F2F2F2",
+        header: "#CCCCCC",
+      },
       fontSize: {
         xxs: "0.5rem",
       },


### PR DESCRIPTION
# 작업내용
- header와 progressBar를 합쳐 현재 카드 인덱스에 따라 헤더가 움직이게 구현
- 이에 따라 카드의 index를 컨트롤하는 로직을 `RandomWrapper`로 뺐음 (추후 `IndexController` 등으로 바꿔야 할 것)
- `useContext` 사용하여 글자 flipping 로직을 `Header`에서 사용할 수 있도록 구현

# TODO
- minor CSS fix