### PR TITLE
Fix/card rendering

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,7 +3,7 @@
  */
 
 // import Card from "@/components/Card";
-import RandomWrapper from "@/components/RandomWrapper";
+import IndexController from "@/components/IndexController";
 import { fetchCards } from "@/lib/fetchCards";
 
 export type CardType = {
@@ -28,8 +28,8 @@ export default async function Home() {
   });
 
   return (
-    <main className="bg-basic z-0 w-full flex-grow overflow-hidden">
-      <RandomWrapper cards={cards} />
+    <main className="z-0 w-full flex-grow overflow-hidden bg-basic">
+      <IndexController cards={cards} />
     </main>
   );
 }

--- a/src/app/playground/page.tsx
+++ b/src/app/playground/page.tsx
@@ -185,7 +185,12 @@ export default function Playground() {
 
   return (
     <main className="h-full w-full overflow-hidden">
-      <Card cards={testCards} currentIndex={startIndex} prevIndex={prevIndex} />
+      <Card
+        cards={testCards}
+        currentIndex={startIndex}
+        prevIndex={prevIndex}
+        flipState={null}
+      />
     </main>
   );
 }

--- a/src/components/Card/index.tsx
+++ b/src/components/Card/index.tsx
@@ -8,10 +8,15 @@ type Props = {
   cards: CardType[];
   currentIndex: number;
   prevIndex: number | null;
+  flipState: string | null;
 };
 
-export default function Card({ cards, currentIndex, prevIndex }: Props) {
-  // const [currentIndex, setCurrentIndex] = useState(startIndex);
+export default function Card({
+  cards,
+  currentIndex,
+  prevIndex,
+  flipState,
+}: Props) {
   // 각 카드들의 회전 각도를 저장하는 state. 처음 렌더링에서 보여질 카드만 0도(앞면)로 설정.
   const [rotationAngles, setRotationAngles] = useState<number[]>(() =>
     Array.from({ length: cards.length }, (_, i) =>
@@ -19,24 +24,22 @@ export default function Card({ cards, currentIndex, prevIndex }: Props) {
     ),
   );
 
-  // currentIndex가 변경될 때마다 회전 각도 업데이트
+  // 다음 장인지 이전 장인지를 props로 받아, rotationAngles를 map 처리
   useEffect(() => {
-    // 다음 카드로 넘기는 경우
-    if (currentIndex > prevIndex!) {
+    if (flipState === "next") {
       setRotationAngles((prevArr) =>
         prevArr.map((val, idx) =>
           idx === currentIndex || idx === prevIndex ? val + 180 : val,
         ),
       );
-    } else {
-      // 이전 카드로 넘기는 경우
+    } else if (flipState === "prev") {
       setRotationAngles((prevArr) =>
         prevArr.map((val, idx) =>
           idx === currentIndex || idx === prevIndex ? val - 180 : val,
         ),
       );
     }
-  }, [currentIndex, cards.length]);
+  }, [currentIndex]);
 
   return (
     <div className="flex h-full w-full flex-col items-center justify-center p-2 lg:p-0">
@@ -64,7 +67,6 @@ export default function Card({ cards, currentIndex, prevIndex }: Props) {
         })}
       </div>
       <Caption cards={cards} currentIndex={currentIndex} />
-      {/* <ProgressBar length={cards.length} currentIndex={currentIndex} /> */}
     </div>
   );
 }

--- a/src/components/IndexController/index.tsx
+++ b/src/components/IndexController/index.tsx
@@ -10,7 +10,7 @@ type Props = {
 };
 
 // 인덱스를 통해 헤더와 카드의 상태를 결정
-export default function RandomWrapper({ cards }: Props) {
+export default function IndexController({ cards }: Props) {
   const [currentIndex, setCurrentIndex] = useState<number | null>(null);
   const [prevIndex, setPrevIndex] = useState<number | null>(null);
 

--- a/src/components/IndexController/index.tsx
+++ b/src/components/IndexController/index.tsx
@@ -13,13 +13,16 @@ type Props = {
 export default function IndexController({ cards }: Props) {
   const [currentIndex, setCurrentIndex] = useState<number | null>(null);
   const [prevIndex, setPrevIndex] = useState<number | null>(null);
+  const [flipState, setFlipState] = useState<string | null>(null);
 
   const handleFlip = (event: React.MouseEvent<HTMLDivElement>) => {
     const divWidth = event.currentTarget.offsetWidth;
     if (event.clientX > divWidth / 2 && currentIndex! < cards.length - 1) {
       setCurrentIndex((prevIndex) => prevIndex! + 1);
+      setFlipState("next");
     } else if (event.clientX < divWidth / 2 && currentIndex! > 0) {
       setCurrentIndex((prevIndex) => prevIndex! - 1);
+      setFlipState("prev");
     }
   };
 
@@ -45,7 +48,12 @@ export default function IndexController({ cards }: Props) {
     <>
       <Header currentIndex={currentIndex} length={cards.length} />
       <div className="flex h-full w-full items-center" onClick={handleFlip}>
-        <Card cards={cards} currentIndex={currentIndex} prevIndex={prevIndex} />
+        <Card
+          cards={cards}
+          currentIndex={currentIndex}
+          prevIndex={prevIndex}
+          flipState={flipState}
+        />
       </div>
     </>
   );


### PR DESCRIPTION
# 작업 내용
- `useEffect`로 인해 초기 렌더링 시에 `Card` component가 한번 뒤집혀서 나오는 이슈 발생. 이를 방지하기 위해 `useEffect` 내부를 조건문으로 처리해줄 필요가 있었고, `flip`이라는 이벤트 발생 시에만 해당 코드가 처리되어야 하니 `flipState`(초기값 `null`)를 props로 내려주는 방식 선택. 이에 따라 처음에는 `flipState`가 `null`이기 때문에 `useEffect`의 효과가 없고, `flip` 액션 발생부터 카드 렌더링을 관리할 수 있음.