### PR TITLE
feat: Add HeaderIndexContext for header position

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,4 +1,5 @@
 import Header from "@/components/Header";
+import IndexController from "@/components/IndexController";
 import { FlippableLink } from "@/components/Link";
 
 export default function About() {

--- a/src/app/contexts/HeaderIndexContext.tsx
+++ b/src/app/contexts/HeaderIndexContext.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { createContext, useContext, useState } from "react";
+
+type HeaderIndexContextType = {
+  headerIndex: number;
+  setHeaderIndex: (index: number) => void;
+  cardsLength: number;
+  setCardsLength: (length: number) => void;
+};
+
+const HeaderIndexContext = createContext<HeaderIndexContextType | null>(null);
+
+const useHeaderIndexContext = () => {
+  const context = useContext(HeaderIndexContext);
+  if (!context) {
+    throw new Error("Cannot find HeaderIndexContext");
+  }
+  return context;
+};
+
+const HeaderIndexProvider = ({ children }: { children: React.ReactNode }) => {
+  const [headerIndex, setHeaderIndex] = useState<number>(0);
+  const [cardsLength, setCardsLength] = useState<number>(0);
+
+  return (
+    <HeaderIndexContext.Provider
+      value={{ headerIndex, setHeaderIndex, cardsLength, setCardsLength }}
+    >
+      {children}
+    </HeaderIndexContext.Provider>
+  );
+};
+
+export { useHeaderIndexContext, HeaderIndexProvider };

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import Head from "next/head";
 import { Viewport } from "next";
 import "./globals.css";
+import { HeaderIndexProvider } from "./contexts/HeaderIndexContext";
 
 export const metadata: Metadata = {
   title: "flips and turns",
@@ -26,7 +27,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className="relative flex h-dvh w-screen min-w-[300px] flex-col">
-        {children}
+        <HeaderIndexProvider>{children}</HeaderIndexProvider>
       </body>
     </html>
   );

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -5,14 +5,12 @@ import { useState, useEffect } from "react";
 import Tab from "@/components/Tab";
 import Logo from "@/components/Logo";
 import { tabInfo } from "@/lib/tabInfo";
+import { useHeaderIndexContext } from "@/app/contexts/HeaderIndexContext";
 
-type HeaderProps = {
-  currentIndex?: number;
-  length?: number;
-};
+export default function Header() {
+  const { headerIndex, cardsLength } = useHeaderIndexContext();
 
-export default function Header(props: HeaderProps) {
-  const { currentIndex = 0, length = 1 } = props;
+  // const { currentIndex = 0, length = 1 } = props;
   const [windowWidth, setWindowWidth] = useState<number>(
     typeof window !== "undefined" ? window.innerWidth : 0,
   );
@@ -29,12 +27,11 @@ export default function Header(props: HeaderProps) {
     };
   });
 
-  // length === 1은 동적이지 않은 header에 대한 기본값
+  // 헤더의 너비와 위치를 context에 따라 계산
   const maxWidth = 150;
-  const headerWidth =
-    length === 1 ? 150 : Math.max(windowWidth / length, maxWidth);
+  const headerWidth = Math.max(windowWidth / cardsLength, maxWidth);
   const translateX =
-    length === 1 ? 0 : ((windowWidth - maxWidth) / (length - 1)) * currentIndex;
+    ((windowWidth - maxWidth) / (cardsLength - 1)) * headerIndex;
 
   return (
     <header

--- a/src/components/IndexController/index.tsx
+++ b/src/components/IndexController/index.tsx
@@ -1,9 +1,11 @@
 "use client";
 
 import { useState, useEffect, useRef } from "react";
+import { usePathname } from "next/navigation";
 import Card from "@/components/Card";
 import Header from "@/components/Header";
 import { CardType } from "@/app/page";
+import { useHeaderIndexContext } from "@/app/contexts/HeaderIndexContext";
 
 type Props = {
   cards: CardType[];
@@ -12,6 +14,9 @@ type Props = {
 
 // 인덱스를 통해 헤더와 카드의 상태를 결정
 export default function IndexController({ cards, initialIndex }: Props) {
+  const pathName = usePathname();
+  const { setHeaderIndex, setCardsLength } = useHeaderIndexContext();
+
   const [currentIndex, setCurrentIndex] = useState<number | null>(null);
   const [prevIndex, setPrevIndex] = useState<number | null>(null);
   const [flipState, setFlipState] = useState<string | null>(null);
@@ -44,7 +49,7 @@ export default function IndexController({ cards, initialIndex }: Props) {
   // 클라이언트 사이드에서 랜덤한 인덱스 설정 (서버 캐싱 방지)
   useEffect(() => {
     const randomIndex = Math.floor(Math.random() * cards.length);
-    initialIndex ? setCurrentIndex(initialIndex) : setCurrentIndex(randomIndex);
+    setCurrentIndex(initialIndex ?? randomIndex);
   }, [cards.length, initialIndex]);
 
   // prevIndex를 Card Component에 props로 전달해주기 위함
@@ -54,6 +59,14 @@ export default function IndexController({ cards, initialIndex }: Props) {
     }
   }, [currentIndex]);
 
+  // 헤더 인덱스 및 카드 길이를 context에 주입
+  useEffect(() => {
+    if (pathName === "/" && currentIndex !== null) {
+      setHeaderIndex(currentIndex);
+      setCardsLength(cards.length);
+    }
+  }, [currentIndex, pathName, setHeaderIndex, cards.length, setCardsLength]);
+
   // Fallback UI
   if (currentIndex === null) {
     return <div>Loading...</div>;
@@ -61,15 +74,17 @@ export default function IndexController({ cards, initialIndex }: Props) {
 
   return (
     <>
-      <Header currentIndex={currentIndex} length={cards.length} />
-      <div className={`flex h-full w-full items-center`} onClick={handleFlip}>
-        <Card
-          cards={cards}
-          currentIndex={currentIndex}
-          prevIndex={prevIndex}
-          flipState={flipState}
-        />
-      </div>
+      <Header />
+      {pathName === "/" && (
+        <div className={`flex h-full w-full items-center`} onClick={handleFlip}>
+          <Card
+            cards={cards}
+            currentIndex={currentIndex}
+            prevIndex={prevIndex}
+            flipState={flipState}
+          />
+        </div>
+      )}
     </>
   );
 }


### PR DESCRIPTION
# 작업내용
- `HeaderIndexContext`를 만들어 header의 index와 cardslength를 전역 컨텍스트로 사용할 수 있게 변환
- 이에 따라 각 페이지에서 홈의 헤더 위치를 그대로 사용할 수 있음